### PR TITLE
Expand on tests: add spinner test; add pytest, pytest-qt as extra reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You can install `napari-brightness-contrast` via [pip]:
 
 ## Contributing
 
-Contributions are very welcome. After cloning the repo, install using `pip install -e .[tests]` to enable testing via `pytest`.
+Contributions are very welcome. 
+After cloning the repo, install using `pip install -e .[tests]` to enable testing via `pytest`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can install `napari-brightness-contrast` via [pip]:
 
 ## Contributing
 
-Contributions are very welcome.
+Contributions are very welcome. After cloning the repo, install using `pip install -e .[tests]` to enable testing via `pytest`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can install `napari-brightness-contrast` via [pip]:
 
 ## Contributing
 
-Contributions are very welcome. 
+Contributions are very welcome.  
 After cloning the repo, install using `pip install -e .[tests]` to enable testing via `pytest`.
 
 ## License

--- a/napari_brightness_contrast/_tests/test_dock_widget.py
+++ b/napari_brightness_contrast/_tests/test_dock_widget.py
@@ -47,7 +47,7 @@ def test_nonimage(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
     # Make a viewer, etc. as before
     viewer = make_napari_viewer()
     image = np.random.randint(256, size=(100, 100), dtype=np.uint8)
-    viewer.add_image(image)
+    viewer.add_image(image, name="img")
     bc = BrightnessContrast(viewer)
     viewer.window.add_dock_widget(bc)
 

--- a/napari_brightness_contrast/_tests/test_dock_widget.py
+++ b/napari_brightness_contrast/_tests/test_dock_widget.py
@@ -1,13 +1,14 @@
+from napari_brightness_contrast._dock_widget import BrightnessContrast
 from typing import Callable
 
 import napari
+import numpy as np
 
 
 def test_widget_added(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
+    # Make a viewer
     viewer = make_napari_viewer()
     assert len(viewer.window._dock_widgets) == 0
-
-    import numpy as np
 
     # Make a test image uint8, so we know the full range
     image = np.random.randint(256, size=(100, 100), dtype=np.uint8)
@@ -16,12 +17,19 @@ def test_widget_added(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
 
     num_dw = len(viewer.window._dock_widgets)
 
-    from napari_brightness_contrast._dock_widget import BrightnessContrast
-
     bc = BrightnessContrast(viewer)
     viewer.window.add_dock_widget(bc)
     # Check widget was added
     assert len(viewer.window._dock_widgets) == num_dw + 1
+
+
+def test_spinners(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
+    # Make a viewer, etc. as before
+    viewer = make_napari_viewer()
+    image = np.random.randint(256, size=(100, 100), dtype=np.uint8)
+    viewer.add_image(image)
+    bc = BrightnessContrast(viewer)
+    viewer.window.add_dock_widget(bc)
 
     # Test the spinners: set values and then apply
     bc.spinner_lower_absolute.setValue(10)
@@ -30,7 +38,39 @@ def test_widget_added(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
     # Check that the contrast limits match the set values
     assert viewer.layers[-1].contrast_limits == [10, 50]
 
-    #    bc._auto_percentiles()
     # Reset back to full range, which should be 0, 255 (image is uint8)
     bc._set_full_range()
     assert viewer.layers[-1].contrast_limits == [0, 255]
+
+
+def test_nonimage(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
+    # Make a viewer, etc. as before
+    viewer = make_napari_viewer()
+    image = np.random.randint(256, size=(100, 100), dtype=np.uint8)
+    viewer.add_image(image)
+    bc = BrightnessContrast(viewer)
+    viewer.window.add_dock_widget(bc)
+
+    # Set values and then apply
+    bc.spinner_lower_absolute.setValue(10)
+    bc.spinner_upper_absolute.setValue(50)
+    bc._set_absolutes()
+    # Check that the contrast limits match the set values
+    assert viewer.layers["img"].contrast_limits == [10, 50]
+
+    # add Shape layer
+    viewer.add_shapes(None, name="shape")
+
+    # Try to set contrasts
+    bc._set_absolutes()
+    # Check that they were not changed
+    assert viewer.layers["img"].contrast_limits == [10, 50]
+
+    # Select the image layer and change settings
+    viewer.layers.selection.active = viewer.layers["img"]
+    bc.spinner_lower_absolute.setValue(20)
+    bc.spinner_upper_absolute.setValue(70)
+    bc._set_absolutes()
+
+    # Check that the contrast limits match the new set values
+    assert viewer.layers["img"].contrast_limits == [20, 70]

--- a/napari_brightness_contrast/_tests/test_dock_widget.py
+++ b/napari_brightness_contrast/_tests/test_dock_widget.py
@@ -1,22 +1,36 @@
-import napari_brightness_contrast
-import pytest
+from typing import Callable
+
+import napari
 
 
-def test_something_with_viewer(make_napari_viewer):
+def test_widget_added(make_napari_viewer: Callable[..., napari.Viewer]) -> None:
     viewer = make_napari_viewer()
+    assert len(viewer.window._dock_widgets) == 0
 
     import numpy as np
-    image = np.random.random((100, 100))
+
+    # Make a test image uint8, so we know the full range
+    image = np.random.randint(256, size=(100, 100), dtype=np.uint8)
 
     viewer.add_image(image)
 
     num_dw = len(viewer.window._dock_widgets)
 
     from napari_brightness_contrast._dock_widget import BrightnessContrast
+
     bc = BrightnessContrast(viewer)
     viewer.window.add_dock_widget(bc)
+    # Check widget was added
     assert len(viewer.window._dock_widgets) == num_dw + 1
 
+    # Test the spinners: set values and then apply
+    bc.spinner_lower_absolute.setValue(10)
+    bc.spinner_upper_absolute.setValue(50)
     bc._set_absolutes()
-    bc._auto_percentiles()
+    # Check that the contrast limits match the set values
+    assert viewer.layers[-1].contrast_limits == [10, 50]
+
+    #    bc._auto_percentiles()
+    # Reset back to full range, which should be 0, 255 (image is uint8)
     bc._set_full_range()
+    assert viewer.layers[-1].contrast_limits == [0, 255]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,11 @@ install_requires =
     superqt
     napari-tools-menu
 
-
+[options.extras_require]
+tests =
+    pytest
+    pytest-qt
+    
 [options.entry_points] 
 napari.plugin = 
     napari-brightness-contrast = napari_brightness_contrast


### PR DESCRIPTION
This PR cleans up and expands on the existing test.
A new test is added to test setting spinner values vs. resultant contrast settings.
A new test is added to test adding a non-image layer (shapes).
Also, optional requirements are added to enable testing (pytest, pytest-qt).

Edit: note, the non-image layer test will currently fail!
